### PR TITLE
Feature: Adding xAuth support

### DIFF
--- a/STLOAuthClient.h
+++ b/STLOAuthClient.h
@@ -53,4 +53,12 @@
                                 parameters:(NSDictionary *)parameters;
 
 
+#pragma mark - xAuth support
+
+- (NSURLRequest *) xAuthSignedRequestWithMethod:(NSString *)method
+                                           path:(NSString *)path
+                                       username:(NSString *)username
+                                       password:(NSString *)password
+                                     parameters:(NSDictionary *)parameters;
+
 @end


### PR DESCRIPTION
Can now optionally generate a signed request with a username and password

I'm not really sure this is implemented the best way. The issue is that the query param fixes inadvertently broke xAuth support. In fact, the sample in the README doesn't work anymore.

```
STLOAuthClient *client = [[STLOAuthClient alloc] initWithBaseURL:[NSURL URLWithString:@"https://www.readability.com/api/rest/v1/"]];
[client setConsumerKey:CONSUMER_KEY secret:CONSUMER_SECRET];
NSDictionary *params = [NSDictionary dictionaryWithObjectsAndKeys:
                        username, @"x_auth_username", 
                        password, @"x_auth_password",
                        @"client_auth", @"x_auth_mode",
                        nil];

[client getPath:@"oauth/access_token/" parameters:params success:^(AFHTTPRequestOperation *operation, id responseObject) {
  NSLog(@"SUccess %@", operation.responseString);
} failure:^(AFHTTPRequestOperation *operation, NSError *error) {
  NSLog(@"Failure, %@", error);
}];
```

This includes xAuth params with the OAuth params, so everything is correctly signed.

I would appreciate feedback on this feature/fix. Maybe there is an easier way to do it?
